### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ powercap (0.2.0-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 08:26:48 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+powercap (0.2.0-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 08:26:48 +0000
+
 powercap (0.2.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Build-Depends: debhelper-compat (= 12),
                cmake
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Vcs-Browser: https://github.com/connorimes/powercap/tree/debian
 Vcs-Git: https://github.com/connorimes/powercap.git -b debian
 Homepage: https://github.com/powercap/powercap

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/powercap/powercap/issues
+Bug-Submit: https://github.com/powercap/powercap/issues/new
+Repository: https://github.com/powercap/powercap.git
+Repository-Browse: https://github.com/powercap/powercap


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/powercap/e0ddafa5-5744-4b6a-95c2-7db71436d920.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/20/09d7ae440de7c7217c12bbdf8badded9ba320a.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/80/da61838930d3debb6632d49f9156e1a9ff5af7.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/92/67a6c9f13c8a16a2a630f0c6042ecaffcba3f9.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/aa/c4b357d1406a79daffd14ead4e5659b6dfaa44.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/df/c3839fa7f67e5a550d552ff809b7587d4fca44.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/19/644194f35f121a837c443b16b061fcf00b0014.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/34/c1f2e1051c38719bbc165a23eb6e23d89b504d.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/50/bc1b255a792299ee6388571828f46ba3cb3307.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/7b/0285e5162a424554faa52b7039128d91baf91b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/e5/ecf8118a203d673a6f1fe731246fa5ce590bfc.debug

No differences were encountered between the control files of package \*\*libpowercap-dev\*\*

No differences were encountered between the control files of package \*\*libpowercap0\*\*
### Control files of package libpowercap0-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-19644194f35f121a837c443b16b061fcf00b0014-] {+dfc3839fa7f67e5a550d552ff809b7587d4fca44+}

No differences were encountered between the control files of package \*\*powercap-utils\*\*
### Control files of package powercap-utils-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-34c1f2e1051c38719bbc165a23eb6e23d89b504d 50bc1b255a792299ee6388571828f46ba3cb3307 7b0285e5162a424554faa52b7039128d91baf91b e5ecf8118a203d673a6f1fe731246fa5ce590bfc-] {+2009d7ae440de7c7217c12bbdf8badded9ba320a 80da61838930d3debb6632d49f9156e1a9ff5af7 9267a6c9f13c8a16a2a630f0c6042ecaffcba3f9 aac4b357d1406a79daffd14ead4e5659b6dfaa44+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e0ddafa5-5744-4b6a-95c2-7db71436d920/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e0ddafa5-5744-4b6a-95c2-7db71436d920/diffoscope)).
