### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 powercap (0.6.0-2) UNRELEASED; urgency=medium
 
   * Update standards version to 4.6.2, no changes needed.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 05 Jan 2023 08:09:56 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+powercap (0.6.0-2) UNRELEASED; urgency=medium
+
+  * Update standards version to 4.6.2, no changes needed.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 05 Jan 2023 08:09:56 -0000
+
 powercap (0.6.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Build-Depends: debhelper-compat (= 13),
                cmake
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Vcs-Browser: https://github.com/connorimes/powercap/tree/debian
 Vcs-Git: https://github.com/connorimes/powercap.git -b debian
 Homepage: https://github.com/powercap/powercap

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,6 @@
 #export DH_VERBOSE = 1
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
Fix some issues reported by lintian

* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/04/5e96f2665924e03b721b84f4f200d9a6e108f5.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/40/bc494925e4e3fd2b05a6b5f9dbabcb65cee9ed.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a6/90bf0cb0dfc3a9e3df2e3de9ab6c08e2a67b61.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c9/94de262e3502dcb889362ed1117dd149bfff80.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/f9/cd53d64bd6204898a7d34bf9c3028685d2b826.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0e/7533b238f45cbf068bbe775095ff5d7c09189e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/29/c628fb65be57262c776373c07339de8a3173f9.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/75/d094da2096b0196cf95229892843340ce54f1c.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ba/cd965b0ad9cbdd612da5b507a11cb50f64bbe4.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/be/312dab1e03078435085682ffdc22d2170b5eab.debug

No differences were encountered between the control files of package \*\*libpowercap-dev\*\*

No differences were encountered between the control files of package \*\*libpowercap0\*\*
### Control files of package libpowercap0-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-be312dab1e03078435085682ffdc22d2170b5eab-] {+40bc494925e4e3fd2b05a6b5f9dbabcb65cee9ed+}

No differences were encountered between the control files of package \*\*powercap-utils\*\*
### Control files of package powercap-utils-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-0e7533b238f45cbf068bbe775095ff5d7c09189e 29c628fb65be57262c776373c07339de8a3173f9 75d094da2096b0196cf95229892843340ce54f1c bacd965b0ad9cbdd612da5b507a11cb50f64bbe4-] {+045e96f2665924e03b721b84f4f200d9a6e108f5 a690bf0cb0dfc3a9e3df2e3de9ab6c08e2a67b61 c994de262e3502dcb889362ed1117dd149bfff80 f9cd53d64bd6204898a7d34bf9c3028685d2b826+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f15b236c-1937-4166-88a1-1759fe82b42f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f15b236c-1937-4166-88a1-1759fe82b42f/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/powercap/f15b236c-1937-4166-88a1-1759fe82b42f.